### PR TITLE
scripts: genpinctrl: remove pwm variant for timer channels 

### DIFF
--- a/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
@@ -172,105 +172,105 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
@@ -160,125 +160,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f030cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030cctx-pinctrl.dtsi
@@ -218,129 +218,129 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f030f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030f4px-pinctrl.dtsi
@@ -92,53 +92,53 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 

--- a/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
@@ -128,85 +128,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
@@ -184,141 +184,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f030rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030rctx-pinctrl.dtsi
@@ -252,145 +252,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
@@ -204,141 +204,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
@@ -136,97 +136,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
@@ -111,73 +111,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 

--- a/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
@@ -160,109 +160,109 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
@@ -166,117 +166,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
@@ -160,113 +160,113 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
@@ -204,141 +204,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
@@ -136,97 +136,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f038f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038f6px-pinctrl.dtsi
@@ -107,61 +107,61 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 

--- a/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
@@ -156,97 +156,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
@@ -166,117 +166,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -260,141 +260,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -260,141 +260,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -153,81 +153,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -153,81 +153,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -202,113 +202,113 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -208,117 +208,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -208,117 +208,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -208,117 +208,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -238,141 +238,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -180,101 +180,101 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -190,117 +190,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
@@ -166,161 +166,161 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
@@ -166,161 +166,161 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
@@ -166,161 +166,161 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
@@ -166,161 +166,161 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
@@ -198,161 +198,161 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
@@ -198,161 +198,161 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
@@ -154,121 +154,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
@@ -160,125 +160,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
@@ -154,121 +154,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
@@ -160,125 +160,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
@@ -154,121 +154,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
@@ -160,125 +160,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
@@ -210,177 +210,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
@@ -210,177 +210,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -222,177 +222,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -222,177 +222,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
@@ -154,121 +154,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
@@ -198,161 +198,161 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -222,177 +222,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -222,177 +222,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
@@ -154,121 +154,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -152,105 +152,105 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
@@ -182,129 +182,129 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -110,57 +110,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 

--- a/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
@@ -216,145 +216,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
@@ -246,165 +246,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
@@ -246,165 +246,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
@@ -246,165 +246,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
@@ -284,181 +284,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
@@ -350,241 +350,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
@@ -350,241 +350,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -268,165 +268,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -268,165 +268,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -268,165 +268,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -306,181 +306,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -306,181 +306,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -306,181 +306,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -381,241 +381,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -381,241 +381,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -246,165 +246,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -246,165 +246,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -246,165 +246,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -284,181 +284,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -284,181 +284,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -350,241 +350,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -350,241 +350,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -304,165 +304,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -304,165 +304,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -342,181 +342,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -342,181 +342,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -342,181 +342,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -417,241 +417,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -417,241 +417,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -304,165 +304,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -304,165 +304,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -342,181 +342,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -342,181 +342,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -342,181 +342,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -417,241 +417,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -417,241 +417,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF0)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF0)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF0)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF0)>;
 			};
 

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -438,225 +438,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -438,225 +438,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -438,225 +438,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -447,277 +447,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -491,293 +491,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -742,345 +742,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -742,345 +742,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -592,277 +592,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -656,293 +656,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -438,225 +438,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -447,277 +447,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -491,293 +491,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -742,345 +742,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -742,345 +742,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -592,277 +592,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -656,293 +656,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
@@ -260,169 +260,169 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
@@ -260,169 +260,169 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
@@ -207,125 +207,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
@@ -203,121 +203,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
@@ -306,185 +306,185 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -282,169 +282,169 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -269,229 +269,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -282,169 +282,169 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -216,121 +216,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -328,185 +328,185 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -337,245 +337,245 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -392,261 +392,261 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -375,341 +375,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -475,357 +475,357 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -475,357 +475,357 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -371,321 +371,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -479,357 +479,357 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
@@ -196,201 +196,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -297,273 +297,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 

--- a/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
@@ -212,205 +212,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
@@ -155,157 +155,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
@@ -151,149 +151,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
@@ -236,233 +236,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -365,317 +365,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -420,333 +420,333 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -491,417 +491,417 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -591,461 +591,461 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -591,461 +591,461 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -463,397 +463,397 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -557,441 +557,441 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -595,509 +595,509 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf3: tim20_ch4_pwm_pf3 {
+			tim20_ch4_pf3: tim20_ch4_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pf4: tim20_ch1n_pwm_pf4 {
+			tim20_ch1n_pf4: tim20_ch1n_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF3)>;
 			};
 
-			tim20_ch2n_pwm_pf5: tim20_ch2n_pwm_pf5 {
+			tim20_ch2n_pf5: tim20_ch2n_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim20_ch1_pwm_pf12: tim20_ch1_pwm_pf12 {
+			tim20_ch1_pf12: tim20_ch1_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, AF2)>;
 			};
 
-			tim20_ch2_pwm_pf13: tim20_ch2_pwm_pf13 {
+			tim20_ch2_pf13: tim20_ch2_pf13 {
 				pinmux = <STM32_PINMUX('F', 13, AF2)>;
 			};
 
-			tim20_ch3_pwm_pf14: tim20_ch3_pwm_pf14 {
+			tim20_ch3_pf14: tim20_ch3_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf15: tim20_ch4_pwm_pf15 {
+			tim20_ch4_pf15: tim20_ch4_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pg0: tim20_ch1n_pwm_pg0 {
+			tim20_ch1n_pg0: tim20_ch1n_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF2)>;
 			};
 
-			tim20_ch2n_pwm_pg1: tim20_ch2n_pwm_pg1 {
+			tim20_ch2n_pg1: tim20_ch2n_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF2)>;
 			};
 
-			tim20_ch3n_pwm_pg2: tim20_ch3n_pwm_pg2 {
+			tim20_ch3n_pg2: tim20_ch3n_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF2)>;
 			};
 
-			tim20_ch1_pwm_ph0: tim20_ch1_pwm_ph0 {
+			tim20_ch1_ph0: tim20_ch1_ph0 {
 				pinmux = <STM32_PINMUX('H', 0, AF2)>;
 			};
 
-			tim20_ch2_pwm_ph1: tim20_ch2_pwm_ph1 {
+			tim20_ch2_ph1: tim20_ch2_ph1 {
 				pinmux = <STM32_PINMUX('H', 1, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
@@ -260,169 +260,169 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
@@ -260,169 +260,169 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
@@ -197,117 +197,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 

--- a/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
@@ -192,201 +192,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -196,201 +196,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -212,205 +212,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -155,157 +155,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -151,149 +151,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -236,233 +236,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -293,273 +293,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -361,317 +361,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -487,417 +487,417 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -415,289 +415,289 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -523,349 +523,349 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim13_ch1_pwm_pc4: tim13_ch1_pwm_pc4 {
+			tim13_ch1_pc4: tim13_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pc0: tim5_ch1_pwm_pc0 {
+			tim5_ch1_pc0: tim5_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc1: tim5_ch2_pwm_pc1 {
+			tim5_ch2_pc1: tim5_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc2: tim5_ch3_pwm_pc2 {
+			tim5_ch3_pc2: tim5_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pc3: tim5_ch4_pwm_pc3 {
+			tim5_ch4_pc3: tim5_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 
-			tim19_ch1_pwm_pc10: tim19_ch1_pwm_pc10 {
+			tim19_ch1_pc10: tim19_ch1_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim19_ch2_pwm_pc11: tim19_ch2_pwm_pc11 {
+			tim19_ch2_pc11: tim19_ch2_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim19_ch3_pwm_pc12: tim19_ch3_pwm_pc12 {
+			tim19_ch3_pc12: tim19_ch3_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -569,377 +569,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim13_ch1_pwm_pc4: tim13_ch1_pwm_pc4 {
+			tim13_ch1_pc4: tim13_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pc0: tim5_ch1_pwm_pc0 {
+			tim5_ch1_pc0: tim5_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc1: tim5_ch2_pwm_pc1 {
+			tim5_ch2_pc1: tim5_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc2: tim5_ch3_pwm_pc2 {
+			tim5_ch3_pc2: tim5_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pc3: tim5_ch4_pwm_pc3 {
+			tim5_ch4_pc3: tim5_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 
-			tim19_ch1_pwm_pc10: tim19_ch1_pwm_pc10 {
+			tim19_ch1_pc10: tim19_ch1_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim19_ch2_pwm_pc11: tim19_ch2_pwm_pc11 {
+			tim19_ch2_pc11: tim19_ch2_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim19_ch3_pwm_pc12: tim19_ch3_pwm_pc12 {
+			tim19_ch3_pc12: tim19_ch3_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim19_ch4_pwm_pd0: tim19_ch4_pwm_pd0 {
+			tim19_ch4_pd0: tim19_ch4_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -569,377 +569,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim13_ch1_pwm_pc4: tim13_ch1_pwm_pc4 {
+			tim13_ch1_pc4: tim13_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pc0: tim5_ch1_pwm_pc0 {
+			tim5_ch1_pc0: tim5_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc1: tim5_ch2_pwm_pc1 {
+			tim5_ch2_pc1: tim5_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc2: tim5_ch3_pwm_pc2 {
+			tim5_ch3_pc2: tim5_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pc3: tim5_ch4_pwm_pc3 {
+			tim5_ch4_pc3: tim5_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 
-			tim19_ch1_pwm_pc10: tim19_ch1_pwm_pc10 {
+			tim19_ch1_pc10: tim19_ch1_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim19_ch2_pwm_pc11: tim19_ch2_pwm_pc11 {
+			tim19_ch2_pc11: tim19_ch2_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim19_ch3_pwm_pc12: tim19_ch3_pwm_pc12 {
+			tim19_ch3_pc12: tim19_ch3_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim19_ch4_pwm_pd0: tim19_ch4_pwm_pd0 {
+			tim19_ch4_pd0: tim19_ch4_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -415,289 +415,289 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -523,349 +523,349 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim13_ch1_pwm_pc4: tim13_ch1_pwm_pc4 {
+			tim13_ch1_pc4: tim13_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pc0: tim5_ch1_pwm_pc0 {
+			tim5_ch1_pc0: tim5_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc1: tim5_ch2_pwm_pc1 {
+			tim5_ch2_pc1: tim5_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc2: tim5_ch3_pwm_pc2 {
+			tim5_ch3_pc2: tim5_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pc3: tim5_ch4_pwm_pc3 {
+			tim5_ch4_pc3: tim5_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 
-			tim19_ch1_pwm_pc10: tim19_ch1_pwm_pc10 {
+			tim19_ch1_pc10: tim19_ch1_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim19_ch2_pwm_pc11: tim19_ch2_pwm_pc11 {
+			tim19_ch2_pc11: tim19_ch2_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim19_ch3_pwm_pc12: tim19_ch3_pwm_pc12 {
+			tim19_ch3_pc12: tim19_ch3_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -523,349 +523,349 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim13_ch1_pwm_pc4: tim13_ch1_pwm_pc4 {
+			tim13_ch1_pc4: tim13_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pc0: tim5_ch1_pwm_pc0 {
+			tim5_ch1_pc0: tim5_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc1: tim5_ch2_pwm_pc1 {
+			tim5_ch2_pc1: tim5_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc2: tim5_ch3_pwm_pc2 {
+			tim5_ch3_pc2: tim5_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pc3: tim5_ch4_pwm_pc3 {
+			tim5_ch4_pc3: tim5_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 
-			tim19_ch1_pwm_pc10: tim19_ch1_pwm_pc10 {
+			tim19_ch1_pc10: tim19_ch1_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim19_ch2_pwm_pc11: tim19_ch2_pwm_pc11 {
+			tim19_ch2_pc11: tim19_ch2_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim19_ch3_pwm_pc12: tim19_ch3_pwm_pc12 {
+			tim19_ch3_pc12: tim19_ch3_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -569,377 +569,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim13_ch1_pwm_pc4: tim13_ch1_pwm_pc4 {
+			tim13_ch1_pc4: tim13_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pc0: tim5_ch1_pwm_pc0 {
+			tim5_ch1_pc0: tim5_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc1: tim5_ch2_pwm_pc1 {
+			tim5_ch2_pc1: tim5_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc2: tim5_ch3_pwm_pc2 {
+			tim5_ch3_pc2: tim5_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pc3: tim5_ch4_pwm_pc3 {
+			tim5_ch4_pc3: tim5_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 
-			tim19_ch1_pwm_pc10: tim19_ch1_pwm_pc10 {
+			tim19_ch1_pc10: tim19_ch1_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim19_ch2_pwm_pc11: tim19_ch2_pwm_pc11 {
+			tim19_ch2_pc11: tim19_ch2_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim19_ch3_pwm_pc12: tim19_ch3_pwm_pc12 {
+			tim19_ch3_pc12: tim19_ch3_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim19_ch4_pwm_pd0: tim19_ch4_pwm_pd0 {
+			tim19_ch4_pd0: tim19_ch4_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -569,377 +569,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim12_ch1_pwm_pa4: tim12_ch1_pwm_pa4 {
+			tim12_ch1_pa4: tim12_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa5: tim12_ch2_pwm_pa5 {
+			tim12_ch2_pa5: tim12_ch2_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim12_ch1_pwm_pa14: tim12_ch1_pwm_pa14 {
+			tim12_ch1_pa14: tim12_ch1_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
 			};
 
-			tim12_ch2_pwm_pa15: tim12_ch2_pwm_pa15 {
+			tim12_ch2_pa15: tim12_ch2_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa9: tim13_ch1_pwm_pa9 {
+			tim13_ch1_pa9: tim13_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb0: tim3_ch2_pwm_pb0 {
+			tim3_ch2_pb0: tim3_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim13_ch1_pwm_pb3: tim13_ch1_pwm_pb3 {
+			tim13_ch1_pb3: tim13_ch1_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb6: tim3_ch3_pwm_pb6 {
+			tim3_ch3_pb6: tim3_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim13_ch1_pwm_pc4: tim13_ch1_pwm_pc4 {
+			tim13_ch1_pc4: tim13_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa5: tim14_ch1_pwm_pa5 {
+			tim14_ch1_pa5: tim14_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa10: tim14_ch1_pwm_pa10 {
+			tim14_ch1_pa10: tim14_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF9)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa8: tim5_ch1_pwm_pa8 {
+			tim5_ch1_pa8: tim5_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa11: tim5_ch2_pwm_pa11 {
+			tim5_ch2_pa11: tim5_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa12: tim5_ch3_pwm_pa12 {
+			tim5_ch3_pa12: tim5_ch3_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa13: tim5_ch4_pwm_pa13 {
+			tim5_ch4_pa13: tim5_ch4_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb4: tim15_ch1n_pwm_pb4 {
+			tim15_ch1n_pb4: tim15_ch1n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb6: tim15_ch1_pwm_pb6 {
+			tim15_ch1_pb6: tim15_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF9)>;
 			};
 
-			tim15_ch2_pwm_pb7: tim15_ch2_pwm_pb7 {
+			tim15_ch2_pb7: tim15_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pc0: tim5_ch1_pwm_pc0 {
+			tim5_ch1_pc0: tim5_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc1: tim5_ch2_pwm_pc1 {
+			tim5_ch2_pc1: tim5_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc2: tim5_ch3_pwm_pc2 {
+			tim5_ch3_pc2: tim5_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pc3: tim5_ch4_pwm_pc3 {
+			tim5_ch4_pc3: tim5_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim19_ch1_pwm_pa0: tim19_ch1_pwm_pa0 {
+			tim19_ch1_pa0: tim19_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF11)>;
 			};
 
-			tim19_ch2_pwm_pa1: tim19_ch2_pwm_pa1 {
+			tim19_ch2_pa1: tim19_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 			};
 
-			tim19_ch3_pwm_pa2: tim19_ch3_pwm_pa2 {
+			tim19_ch3_pa2: tim19_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF11)>;
 			};
 
-			tim19_ch4_pwm_pa3: tim19_ch4_pwm_pa3 {
+			tim19_ch4_pa3: tim19_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF11)>;
 			};
 
-			tim19_ch1_pwm_pb6: tim19_ch1_pwm_pb6 {
+			tim19_ch1_pb6: tim19_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
 			};
 
-			tim19_ch2_pwm_pb7: tim19_ch2_pwm_pb7 {
+			tim19_ch2_pb7: tim19_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
-			tim19_ch3_pwm_pb8: tim19_ch3_pwm_pb8 {
+			tim19_ch3_pb8: tim19_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
 			};
 
-			tim19_ch4_pwm_pb9: tim19_ch4_pwm_pb9 {
+			tim19_ch4_pb9: tim19_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
 			};
 
-			tim19_ch1_pwm_pc10: tim19_ch1_pwm_pc10 {
+			tim19_ch1_pc10: tim19_ch1_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim19_ch2_pwm_pc11: tim19_ch2_pwm_pc11 {
+			tim19_ch2_pc11: tim19_ch2_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim19_ch3_pwm_pc12: tim19_ch3_pwm_pc12 {
+			tim19_ch3_pc12: tim19_ch3_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim19_ch4_pwm_pd0: tim19_ch4_pwm_pd0 {
+			tim19_ch4_pd0: tim19_ch4_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -587,461 +587,461 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -252,149 +252,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -252,149 +252,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -252,149 +252,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -252,149 +252,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -252,149 +252,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -320,165 +320,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -320,165 +320,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -385,221 +385,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -379,217 +379,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -385,221 +385,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -379,217 +379,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -460,269 +460,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -460,225 +460,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -469,277 +469,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -513,293 +513,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -769,345 +769,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -769,345 +769,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -614,277 +614,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -678,293 +678,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
@@ -257,73 +257,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb12: tim5_ch1_pwm_pb12 {
+			tim5_ch1_pb12: tim5_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
@@ -278,77 +278,77 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb12: tim5_ch1_pwm_pb12 {
+			tim5_ch1_pb12: tim5_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
@@ -332,101 +332,101 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim11_ch1_pwm_pc12: tim11_ch1_pwm_pc12 {
+			tim11_ch1_pc12: tim11_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pb11: tim5_ch4_pwm_pb11 {
+			tim5_ch4_pb11: tim5_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb12: tim5_ch1_pwm_pb12 {
+			tim5_ch1_pb12: tim5_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc10: tim5_ch2_pwm_pc10 {
+			tim5_ch2_pc10: tim5_ch2_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc11: tim5_ch3_pwm_pc11 {
+			tim5_ch3_pc11: tim5_ch3_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pc4: tim9_ch1_pwm_pc4 {
+			tim9_ch1_pc4: tim9_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF3)>;
 			};
 
-			tim9_ch2_pwm_pc5: tim9_ch2_pwm_pc5 {
+			tim9_ch2_pc5: tim9_ch2_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
@@ -332,101 +332,101 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim11_ch1_pwm_pc12: tim11_ch1_pwm_pc12 {
+			tim11_ch1_pc12: tim11_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pb11: tim5_ch4_pwm_pb11 {
+			tim5_ch4_pb11: tim5_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb12: tim5_ch1_pwm_pb12 {
+			tim5_ch1_pb12: tim5_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
 			};
 
-			tim5_ch2_pwm_pc10: tim5_ch2_pwm_pc10 {
+			tim5_ch2_pc10: tim5_ch2_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim5_ch3_pwm_pc11: tim5_ch3_pwm_pc11 {
+			tim5_ch3_pc11: tim5_ch3_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pc4: tim9_ch1_pwm_pc4 {
+			tim9_ch1_pc4: tim9_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF3)>;
 			};
 
-			tim9_ch2_pwm_pc5: tim9_ch2_pwm_pc5 {
+			tim9_ch2_pc5: tim9_ch2_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
@@ -125,33 +125,33 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb12: tim5_ch1_pwm_pb12 {
+			tim5_ch1_pb12: tim5_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -375,149 +375,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -375,149 +375,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -453,165 +453,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -610,221 +610,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -604,217 +604,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -415,189 +415,189 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -493,221 +493,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -493,221 +493,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -493,221 +493,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -659,277 +659,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -653,273 +653,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -689,309 +689,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf3: tim5_ch1_pwm_pf3 {
+			tim5_ch1_pf3: tim5_ch1_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf4: tim5_ch2_pwm_pf4 {
+			tim5_ch2_pf4: tim5_ch2_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf5: tim5_ch3_pwm_pf5 {
+			tim5_ch3_pf5: tim5_ch3_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf10: tim5_ch4_pwm_pf10 {
+			tim5_ch4_pf10: tim5_ch4_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -689,309 +689,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf3: tim5_ch1_pwm_pf3 {
+			tim5_ch1_pf3: tim5_ch1_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf4: tim5_ch2_pwm_pf4 {
+			tim5_ch2_pf4: tim5_ch2_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf5: tim5_ch3_pwm_pf5 {
+			tim5_ch3_pf5: tim5_ch3_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf10: tim5_ch4_pwm_pf10 {
+			tim5_ch4_pf10: tim5_ch4_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -476,189 +476,189 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -625,245 +625,245 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -554,221 +554,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -720,277 +720,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -714,273 +714,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -750,309 +750,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf3: tim5_ch1_pwm_pf3 {
+			tim5_ch1_pf3: tim5_ch1_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf4: tim5_ch2_pwm_pf4 {
+			tim5_ch2_pf4: tim5_ch2_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf5: tim5_ch3_pwm_pf5 {
+			tim5_ch3_pf5: tim5_ch3_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf10: tim5_ch4_pwm_pf10 {
+			tim5_ch4_pf10: tim5_ch4_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -750,309 +750,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf3: tim5_ch1_pwm_pf3 {
+			tim5_ch1_pf3: tim5_ch1_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf4: tim5_ch2_pwm_pf4 {
+			tim5_ch2_pf4: tim5_ch2_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf5: tim5_ch3_pwm_pf5 {
+			tim5_ch3_pf5: tim5_ch3_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf10: tim5_ch4_pwm_pf10 {
+			tim5_ch4_pf10: tim5_ch4_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -460,269 +460,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -460,225 +460,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -469,277 +469,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -513,293 +513,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -769,345 +769,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -769,345 +769,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -614,277 +614,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -678,293 +678,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -476,189 +476,189 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -625,245 +625,245 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -554,221 +554,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -720,277 +720,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -714,273 +714,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -750,309 +750,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf3: tim5_ch1_pwm_pf3 {
+			tim5_ch1_pf3: tim5_ch1_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf4: tim5_ch2_pwm_pf4 {
+			tim5_ch2_pf4: tim5_ch2_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf5: tim5_ch3_pwm_pf5 {
+			tim5_ch3_pf5: tim5_ch3_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf10: tim5_ch4_pwm_pf10 {
+			tim5_ch4_pf10: tim5_ch4_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -750,309 +750,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf3: tim5_ch1_pwm_pf3 {
+			tim5_ch1_pf3: tim5_ch1_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf4: tim5_ch2_pwm_pf4 {
+			tim5_ch2_pf4: tim5_ch2_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf5: tim5_ch3_pwm_pf5 {
+			tim5_ch3_pf5: tim5_ch3_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf10: tim5_ch4_pwm_pf10 {
+			tim5_ch4_pf10: tim5_ch4_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -822,329 +822,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -673,277 +673,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -822,329 +822,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -673,277 +673,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -673,277 +673,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -822,329 +822,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -673,277 +673,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -822,329 +822,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -888,345 +888,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -673,277 +673,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -782,293 +782,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -576,253 +576,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb2: tim2_ch4_pwm_pb2 {
+			tim2_ch4_pb2: tim2_ch4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pb8: tim2_ch1_pwm_pb8 {
+			tim2_ch1_pb8: tim2_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb9: tim2_ch2_pwm_pb9 {
+			tim2_ch2_pb9: tim2_ch2_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -563,233 +563,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb2: tim2_ch4_pwm_pb2 {
+			tim2_ch4_pb2: tim2_ch4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pb8: tim2_ch1_pwm_pb8 {
+			tim2_ch1_pb8: tim2_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb9: tim2_ch2_pwm_pb9 {
+			tim2_ch2_pb9: tim2_ch2_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -654,285 +654,285 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb2: tim2_ch4_pwm_pb2 {
+			tim2_ch4_pb2: tim2_ch4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pb8: tim2_ch1_pwm_pb8 {
+			tim2_ch1_pb8: tim2_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb9: tim2_ch2_pwm_pb9 {
+			tim2_ch2_pb9: tim2_ch2_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -724,305 +724,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb2: tim2_ch4_pwm_pb2 {
+			tim2_ch4_pb2: tim2_ch4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pb8: tim2_ch1_pwm_pb8 {
+			tim2_ch1_pb8: tim2_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb9: tim2_ch2_pwm_pb9 {
+			tim2_ch2_pb9: tim2_ch2_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -724,305 +724,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb2: tim2_ch4_pwm_pb2 {
+			tim2_ch4_pb2: tim2_ch4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pb8: tim2_ch1_pwm_pb8 {
+			tim2_ch1_pb8: tim2_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb9: tim2_ch2_pwm_pb9 {
+			tim2_ch2_pb9: tim2_ch2_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -724,305 +724,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb2: tim2_ch4_pwm_pb2 {
+			tim2_ch4_pb2: tim2_ch4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pb8: tim2_ch1_pwm_pb8 {
+			tim2_ch1_pb8: tim2_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb9: tim2_ch2_pwm_pb9 {
+			tim2_ch2_pb9: tim2_ch2_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -596,325 +596,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -596,325 +596,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -907,345 +907,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -892,313 +892,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -892,313 +892,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -892,313 +892,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -907,345 +907,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -907,345 +907,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -516,261 +516,261 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -516,261 +516,261 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -575,273 +575,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -575,273 +575,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -596,325 +596,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -596,325 +596,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -907,345 +907,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -892,313 +892,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -892,313 +892,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -907,345 +907,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -516,261 +516,261 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -575,273 +575,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -850,345 +850,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -850,345 +850,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -549,225 +549,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -675,277 +675,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -764,293 +764,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -826,321 +826,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -826,321 +826,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -611,253 +611,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -740,269 +740,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -740,269 +740,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -826,321 +826,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -549,225 +549,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -675,277 +675,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -740,269 +740,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -850,345 +850,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -850,345 +850,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -549,225 +549,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -675,277 +675,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -764,293 +764,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -826,321 +826,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -826,321 +826,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -611,253 +611,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -740,269 +740,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -740,269 +740,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -921,293 +921,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -921,293 +921,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -921,293 +921,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -921,293 +921,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -921,293 +921,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1039,345 +1039,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -800,277 +800,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -921,293 +921,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -921,293 +921,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1125,293 +1125,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1125,293 +1125,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1125,293 +1125,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -937,325 +937,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -937,325 +937,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1216,313 +1216,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1216,313 +1216,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -960,277 +960,277 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1125,293 +1125,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -937,325 +937,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -937,325 +937,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1216,313 +1216,313 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1248,345 +1248,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			tim10_ch1_pf6: tim10_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			tim11_ch1_pf7: tim11_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF9)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF9)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF9)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF9)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -400,149 +400,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g030f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030f6px-pinctrl.dtsi
@@ -305,101 +305,101 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -218,65 +218,65 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -327,113 +327,113 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -400,193 +400,193 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -400,193 +400,193 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
@@ -305,129 +305,129 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
@@ -285,133 +285,133 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -218,81 +218,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -327,145 +327,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -327,145 +327,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
@@ -305,129 +305,129 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -400,193 +400,193 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -400,193 +400,193 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
@@ -305,129 +305,129 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
@@ -285,133 +285,133 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -218,81 +218,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -327,145 +327,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -327,145 +327,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
@@ -305,129 +305,129 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -388,181 +388,181 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -307,125 +307,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -444,221 +444,221 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1_pwm_pc8: tim1_ch1_pwm_pc8 {
+			tim1_ch1_pc8: tim1_ch1_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc9: tim1_ch2_pwm_pc9 {
+			tim1_ch2_pc9: tim1_ch2_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc10: tim1_ch3_pwm_pc10 {
+			tim1_ch3_pc10: tim1_ch3_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc11: tim1_ch4_pwm_pc11 {
+			tim1_ch4_pc11: tim1_ch4_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pd4: tim1_ch3n_pwm_pd4 {
+			tim1_ch3n_pd4: tim1_ch3n_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pc12: tim14_ch1_pwm_pc12 {
+			tim14_ch1_pc12: tim14_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1_pwm_pc1: tim15_ch1_pwm_pc1 {
+			tim15_ch1_pc1: tim15_ch1_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
+			tim15_ch2_pc2: tim15_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -398,225 +398,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -398,225 +398,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -260,125 +260,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -275,145 +275,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -258,141 +258,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -317,157 +317,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -317,157 +317,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -295,165 +295,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -295,165 +295,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -454,273 +454,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1_pwm_pc8: tim1_ch1_pwm_pc8 {
+			tim1_ch1_pc8: tim1_ch1_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc9: tim1_ch2_pwm_pc9 {
+			tim1_ch2_pc9: tim1_ch2_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc10: tim1_ch3_pwm_pc10 {
+			tim1_ch3_pc10: tim1_ch3_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc11: tim1_ch4_pwm_pc11 {
+			tim1_ch4_pc11: tim1_ch4_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pd4: tim1_ch3n_pwm_pd4 {
+			tim1_ch3n_pd4: tim1_ch3n_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch1_pwm_pc4: tim2_ch1_pwm_pc4 {
+			tim2_ch1_pc4: tim2_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim2_ch2_pwm_pc5: tim2_ch2_pwm_pc5 {
+			tim2_ch2_pc5: tim2_ch2_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pc12: tim14_ch1_pwm_pc12 {
+			tim14_ch1_pc12: tim14_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1_pwm_pc1: tim15_ch1_pwm_pc1 {
+			tim15_ch1_pc1: tim15_ch1_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
+			tim15_ch2_pc2: tim15_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -454,273 +454,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1_pwm_pc8: tim1_ch1_pwm_pc8 {
+			tim1_ch1_pc8: tim1_ch1_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc9: tim1_ch2_pwm_pc9 {
+			tim1_ch2_pc9: tim1_ch2_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc10: tim1_ch3_pwm_pc10 {
+			tim1_ch3_pc10: tim1_ch3_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc11: tim1_ch4_pwm_pc11 {
+			tim1_ch4_pc11: tim1_ch4_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pd4: tim1_ch3n_pwm_pd4 {
+			tim1_ch3n_pd4: tim1_ch3n_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch1_pwm_pc4: tim2_ch1_pwm_pc4 {
+			tim2_ch1_pc4: tim2_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim2_ch2_pwm_pc5: tim2_ch2_pwm_pc5 {
+			tim2_ch2_pc5: tim2_ch2_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pc12: tim14_ch1_pwm_pc12 {
+			tim14_ch1_pc12: tim14_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1_pwm_pc1: tim15_ch1_pwm_pc1 {
+			tim15_ch1_pc1: tim15_ch1_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
+			tim15_ch2_pc2: tim15_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -398,225 +398,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -398,225 +398,225 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -260,125 +260,125 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -275,145 +275,145 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -258,141 +258,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -317,157 +317,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -295,165 +295,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -317,157 +317,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -295,165 +295,165 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -454,273 +454,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1_pwm_pc8: tim1_ch1_pwm_pc8 {
+			tim1_ch1_pc8: tim1_ch1_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc9: tim1_ch2_pwm_pc9 {
+			tim1_ch2_pc9: tim1_ch2_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc10: tim1_ch3_pwm_pc10 {
+			tim1_ch3_pc10: tim1_ch3_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc11: tim1_ch4_pwm_pc11 {
+			tim1_ch4_pc11: tim1_ch4_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pd4: tim1_ch3n_pwm_pd4 {
+			tim1_ch3n_pd4: tim1_ch3n_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch1_pwm_pc4: tim2_ch1_pwm_pc4 {
+			tim2_ch1_pc4: tim2_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim2_ch2_pwm_pc5: tim2_ch2_pwm_pc5 {
+			tim2_ch2_pc5: tim2_ch2_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pc12: tim14_ch1_pwm_pc12 {
+			tim14_ch1_pc12: tim14_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1_pwm_pc1: tim15_ch1_pwm_pc1 {
+			tim15_ch1_pc1: tim15_ch1_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
+			tim15_ch2_pc2: tim15_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -454,273 +454,273 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim1_ch2_pwm_pb3: tim1_ch2_pwm_pb3 {
+			tim1_ch2_pb3: tim1_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim1_ch3_pwm_pb6: tim1_ch3_pwm_pb6 {
+			tim1_ch3_pb6: tim1_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim1_ch1_pwm_pc8: tim1_ch1_pwm_pc8 {
+			tim1_ch1_pc8: tim1_ch1_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc9: tim1_ch2_pwm_pc9 {
+			tim1_ch2_pc9: tim1_ch2_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc10: tim1_ch3_pwm_pc10 {
+			tim1_ch3_pc10: tim1_ch3_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc11: tim1_ch4_pwm_pc11 {
+			tim1_ch4_pc11: tim1_ch4_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pd2: tim1_ch1n_pwm_pd2 {
+			tim1_ch1n_pd2: tim1_ch1n_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pd3: tim1_ch2n_pwm_pd3 {
+			tim1_ch2n_pd3: tim1_ch2n_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pd4: tim1_ch3n_pwm_pd4 {
+			tim1_ch3n_pd4: tim1_ch3n_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim2_ch1_pwm_pc4: tim2_ch1_pwm_pc4 {
+			tim2_ch1_pc4: tim2_ch1_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
 			};
 
-			tim2_ch2_pwm_pc5: tim2_ch2_pwm_pc5 {
+			tim2_ch2_pc5: tim2_ch2_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
 			};
 
-			tim2_ch3_pwm_pc6: tim2_ch3_pwm_pc6 {
+			tim2_ch3_pc6: tim2_ch3_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim2_ch4_pwm_pc7: tim2_ch4_pwm_pc7 {
+			tim2_ch4_pc7: tim2_ch4_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
 			};
 
-			tim14_ch1_pwm_pa4: tim14_ch1_pwm_pa4 {
+			tim14_ch1_pa4: tim14_ch1_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF4)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			tim14_ch1_pb1: tim14_ch1_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF0)>;
 			};
 
-			tim14_ch1_pwm_pc12: tim14_ch1_pwm_pc12 {
+			tim14_ch1_pc12: tim14_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf0: tim14_ch1_pwm_pf0 {
+			tim14_ch1_pf0: tim14_ch1_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF5)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF5)>;
 			};
 
-			tim15_ch1_pwm_pc1: tim15_ch1_pwm_pc1 {
+			tim15_ch1_pc1: tim15_ch1_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim15_ch2_pwm_pc2: tim15_ch2_pwm_pc2 {
+			tim15_ch2_pc2: tim15_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pf1: tim15_ch1n_pwm_pf1 {
+			tim15_ch1n_pf1: tim15_ch1n_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim16_ch1_pwm_pd0: tim16_ch1_pwm_pd0 {
+			tim16_ch1_pd0: tim16_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF2)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim17_ch1_pwm_pd1: tim17_ch1_pwm_pd1 {
+			tim17_ch1_pd1: tim17_ch1_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF2)>;
 			};
 

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -354,281 +354,281 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -385,297 +385,297 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -375,293 +375,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -283,213 +283,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -283,213 +283,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -450,385 +450,385 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -442,345 +442,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -442,345 +442,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -465,449 +465,449 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -354,281 +354,281 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -385,297 +385,297 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -375,293 +375,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -283,213 +283,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -283,213 +283,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -450,385 +450,385 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -442,345 +442,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -442,345 +442,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -465,449 +465,449 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -394,301 +394,301 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -431,317 +431,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -554,417 +554,417 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -558,417 +558,417 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -689,505 +689,505 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF6)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF6)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF6)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -494,369 +494,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -610,485 +610,485 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -610,485 +610,485 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -610,485 +610,485 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -434,305 +434,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -471,321 +471,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -658,429 +658,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -670,429 +670,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -825,593 +825,593 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf3: tim20_ch4_pwm_pf3 {
+			tim20_ch4_pf3: tim20_ch4_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pf4: tim20_ch1n_pwm_pf4 {
+			tim20_ch1n_pf4: tim20_ch1n_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF3)>;
 			};
 
-			tim20_ch2n_pwm_pf5: tim20_ch2n_pwm_pf5 {
+			tim20_ch2n_pf5: tim20_ch2n_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim20_ch1_pwm_pf12: tim20_ch1_pwm_pf12 {
+			tim20_ch1_pf12: tim20_ch1_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, AF2)>;
 			};
 
-			tim20_ch2_pwm_pf13: tim20_ch2_pwm_pf13 {
+			tim20_ch2_pf13: tim20_ch2_pf13 {
 				pinmux = <STM32_PINMUX('F', 13, AF2)>;
 			};
 
-			tim20_ch3_pwm_pf14: tim20_ch3_pwm_pf14 {
+			tim20_ch3_pf14: tim20_ch3_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf15: tim20_ch4_pwm_pf15 {
+			tim20_ch4_pf15: tim20_ch4_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pg0: tim20_ch1n_pwm_pg0 {
+			tim20_ch1n_pg0: tim20_ch1n_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF2)>;
 			};
 
-			tim20_ch2n_pwm_pg1: tim20_ch2n_pwm_pg1 {
+			tim20_ch2n_pg1: tim20_ch2n_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF2)>;
 			};
 
-			tim20_ch3n_pwm_pg2: tim20_ch3n_pwm_pg2 {
+			tim20_ch3n_pg2: tim20_ch3n_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF2)>;
 			};
 
-			tim20_ch4n_pwm_pg3: tim20_ch4n_pwm_pg3 {
+			tim20_ch4n_pg3: tim20_ch4n_pg3 {
 				pinmux = <STM32_PINMUX('G', 3, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF6)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF6)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF6)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -534,381 +534,381 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -434,305 +434,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -471,321 +471,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -658,429 +658,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -670,429 +670,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -825,593 +825,593 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf3: tim20_ch4_pwm_pf3 {
+			tim20_ch4_pf3: tim20_ch4_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pf4: tim20_ch1n_pwm_pf4 {
+			tim20_ch1n_pf4: tim20_ch1n_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF3)>;
 			};
 
-			tim20_ch2n_pwm_pf5: tim20_ch2n_pwm_pf5 {
+			tim20_ch2n_pf5: tim20_ch2n_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim20_ch1_pwm_pf12: tim20_ch1_pwm_pf12 {
+			tim20_ch1_pf12: tim20_ch1_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, AF2)>;
 			};
 
-			tim20_ch2_pwm_pf13: tim20_ch2_pwm_pf13 {
+			tim20_ch2_pf13: tim20_ch2_pf13 {
 				pinmux = <STM32_PINMUX('F', 13, AF2)>;
 			};
 
-			tim20_ch3_pwm_pf14: tim20_ch3_pwm_pf14 {
+			tim20_ch3_pf14: tim20_ch3_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf15: tim20_ch4_pwm_pf15 {
+			tim20_ch4_pf15: tim20_ch4_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pg0: tim20_ch1n_pwm_pg0 {
+			tim20_ch1n_pg0: tim20_ch1n_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF2)>;
 			};
 
-			tim20_ch2n_pwm_pg1: tim20_ch2n_pwm_pg1 {
+			tim20_ch2n_pg1: tim20_ch2n_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF2)>;
 			};
 
-			tim20_ch3n_pwm_pg2: tim20_ch3n_pwm_pg2 {
+			tim20_ch3n_pg2: tim20_ch3n_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF2)>;
 			};
 
-			tim20_ch4n_pwm_pg3: tim20_ch4n_pwm_pg3 {
+			tim20_ch4n_pg3: tim20_ch4n_pg3 {
 				pinmux = <STM32_PINMUX('G', 3, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF6)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF6)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF6)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -534,381 +534,381 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -434,305 +434,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -471,321 +471,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -658,429 +658,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -670,429 +670,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -825,593 +825,593 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf3: tim20_ch4_pwm_pf3 {
+			tim20_ch4_pf3: tim20_ch4_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pf4: tim20_ch1n_pwm_pf4 {
+			tim20_ch1n_pf4: tim20_ch1n_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF3)>;
 			};
 
-			tim20_ch2n_pwm_pf5: tim20_ch2n_pwm_pf5 {
+			tim20_ch2n_pf5: tim20_ch2n_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim20_ch1_pwm_pf12: tim20_ch1_pwm_pf12 {
+			tim20_ch1_pf12: tim20_ch1_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, AF2)>;
 			};
 
-			tim20_ch2_pwm_pf13: tim20_ch2_pwm_pf13 {
+			tim20_ch2_pf13: tim20_ch2_pf13 {
 				pinmux = <STM32_PINMUX('F', 13, AF2)>;
 			};
 
-			tim20_ch3_pwm_pf14: tim20_ch3_pwm_pf14 {
+			tim20_ch3_pf14: tim20_ch3_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf15: tim20_ch4_pwm_pf15 {
+			tim20_ch4_pf15: tim20_ch4_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pg0: tim20_ch1n_pwm_pg0 {
+			tim20_ch1n_pg0: tim20_ch1n_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF2)>;
 			};
 
-			tim20_ch2n_pwm_pg1: tim20_ch2n_pwm_pg1 {
+			tim20_ch2n_pg1: tim20_ch2n_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF2)>;
 			};
 
-			tim20_ch3n_pwm_pg2: tim20_ch3n_pwm_pg2 {
+			tim20_ch3n_pg2: tim20_ch3n_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF2)>;
 			};
 
-			tim20_ch4n_pwm_pg3: tim20_ch4n_pwm_pg3 {
+			tim20_ch4n_pg3: tim20_ch4n_pg3 {
 				pinmux = <STM32_PINMUX('G', 3, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF6)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF6)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF6)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -534,381 +534,381 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -434,305 +434,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -471,321 +471,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -658,429 +658,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -670,429 +670,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -825,593 +825,593 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf3: tim20_ch4_pwm_pf3 {
+			tim20_ch4_pf3: tim20_ch4_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pf4: tim20_ch1n_pwm_pf4 {
+			tim20_ch1n_pf4: tim20_ch1n_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF3)>;
 			};
 
-			tim20_ch2n_pwm_pf5: tim20_ch2n_pwm_pf5 {
+			tim20_ch2n_pf5: tim20_ch2n_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF2)>;
 			};
 
-			tim20_ch1_pwm_pf12: tim20_ch1_pwm_pf12 {
+			tim20_ch1_pf12: tim20_ch1_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, AF2)>;
 			};
 
-			tim20_ch2_pwm_pf13: tim20_ch2_pwm_pf13 {
+			tim20_ch2_pf13: tim20_ch2_pf13 {
 				pinmux = <STM32_PINMUX('F', 13, AF2)>;
 			};
 
-			tim20_ch3_pwm_pf14: tim20_ch3_pwm_pf14 {
+			tim20_ch3_pf14: tim20_ch3_pf14 {
 				pinmux = <STM32_PINMUX('F', 14, AF2)>;
 			};
 
-			tim20_ch4_pwm_pf15: tim20_ch4_pwm_pf15 {
+			tim20_ch4_pf15: tim20_ch4_pf15 {
 				pinmux = <STM32_PINMUX('F', 15, AF2)>;
 			};
 
-			tim20_ch1n_pwm_pg0: tim20_ch1n_pwm_pg0 {
+			tim20_ch1n_pg0: tim20_ch1n_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF2)>;
 			};
 
-			tim20_ch2n_pwm_pg1: tim20_ch2n_pwm_pg1 {
+			tim20_ch2n_pg1: tim20_ch2n_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF2)>;
 			};
 
-			tim20_ch3n_pwm_pg2: tim20_ch3n_pwm_pg2 {
+			tim20_ch3n_pg2: tim20_ch3n_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF2)>;
 			};
 
-			tim20_ch4n_pwm_pg3: tim20_ch4n_pwm_pg3 {
+			tim20_ch4n_pg3: tim20_ch4n_pg3 {
 				pinmux = <STM32_PINMUX('G', 3, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim4_ch4_pwm_pf6: tim4_ch4_pwm_pf6 {
+			tim4_ch4_pf6: tim4_ch4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF6)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF6)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF6)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -534,381 +534,381 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -746,529 +746,529 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim20_ch1_pwm_pb2: tim20_ch1_pwm_pb2 {
+			tim20_ch1_pb2: tim20_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF3)>;
 			};
 
-			tim20_ch2_pwm_pc2: tim20_ch2_pwm_pc2 {
+			tim20_ch2_pc2: tim20_ch2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF6)>;
 			};
 
-			tim20_ch3_pwm_pc8: tim20_ch3_pwm_pc8 {
+			tim20_ch3_pc8: tim20_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
 			};
 
-			tim20_ch4n_pwm_pe0: tim20_ch4n_pwm_pe0 {
+			tim20_ch4n_pe0: tim20_ch4n_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim20_ch4_pwm_pe1: tim20_ch4_pwm_pe1 {
+			tim20_ch4_pe1: tim20_ch4_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF6)>;
 			};
 
-			tim20_ch1_pwm_pe2: tim20_ch1_pwm_pe2 {
+			tim20_ch1_pe2: tim20_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
 			};
 
-			tim20_ch2_pwm_pe3: tim20_ch2_pwm_pe3 {
+			tim20_ch2_pe3: tim20_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF6)>;
 			};
 
-			tim20_ch1n_pwm_pe4: tim20_ch1n_pwm_pe4 {
+			tim20_ch1n_pe4: tim20_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF6)>;
 			};
 
-			tim20_ch2n_pwm_pe5: tim20_ch2n_pwm_pe5 {
+			tim20_ch2n_pe5: tim20_ch2n_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF6)>;
 			};
 
-			tim20_ch3n_pwm_pe6: tim20_ch3n_pwm_pe6 {
+			tim20_ch3n_pe6: tim20_ch3n_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF6)>;
 			};
 
-			tim20_ch3_pwm_pf2: tim20_ch3_pwm_pf2 {
+			tim20_ch3_pf2: tim20_ch3_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
 			};
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pc13: tim1_ch1n_pwm_pc13 {
+			tim1_ch1n_pc13: tim1_ch1n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF4)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF2)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF2)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF2)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF2)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pe15: tim1_ch4n_pwm_pe15 {
+			tim1_ch4n_pe15: tim1_ch4n_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pd3: tim2_ch1_pwm_pd3 {
+			tim2_ch1_pd3: tim2_ch1_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF2)>;
 			};
 
-			tim2_ch2_pwm_pd4: tim2_ch2_pwm_pd4 {
+			tim2_ch2_pd4: tim2_ch2_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF2)>;
 			};
 
-			tim2_ch4_pwm_pd6: tim2_ch4_pwm_pd6 {
+			tim2_ch4_pd6: tim2_ch4_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF2)>;
 			};
 
-			tim2_ch3_pwm_pd7: tim2_ch3_pwm_pd7 {
+			tim2_ch3_pd7: tim2_ch3_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe2: tim3_ch1_pwm_pe2 {
+			tim3_ch1_pe2: tim3_ch1_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe3: tim3_ch2_pwm_pe3 {
+			tim3_ch2_pe3: tim3_ch2_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe4: tim3_ch3_pwm_pe4 {
+			tim3_ch3_pe4: tim3_ch3_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe5: tim3_ch4_pwm_pe5 {
+			tim3_ch4_pe5: tim3_ch4_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pb2: tim5_ch1_pwm_pb2 {
+			tim5_ch1_pb2: tim5_ch1_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF2)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim5_ch2_pwm_pc12: tim5_ch2_pwm_pc12 {
+			tim5_ch2_pc12: tim5_ch2_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF1)>;
 			};
 
-			tim5_ch3_pwm_pe8: tim5_ch3_pwm_pe8 {
+			tim5_ch3_pe8: tim5_ch3_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim5_ch4_pwm_pe9: tim5_ch4_pwm_pe9 {
+			tim5_ch4_pe9: tim5_ch4_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF6)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF4)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF4)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pc10: tim8_ch1n_pwm_pc10 {
+			tim8_ch1n_pc10: tim8_ch1n_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pc11: tim8_ch2n_pwm_pc11 {
+			tim8_ch2n_pc11: tim8_ch2n_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pc12: tim8_ch3n_pwm_pc12 {
+			tim8_ch3n_pc12: tim8_ch3n_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF4)>;
 			};
 
-			tim8_ch4n_pwm_pc13: tim8_ch4n_pwm_pc13 {
+			tim8_ch4n_pc13: tim8_ch4n_pc13 {
 				pinmux = <STM32_PINMUX('C', 13, AF6)>;
 			};
 
-			tim8_ch4n_pwm_pd0: tim8_ch4n_pwm_pd0 {
+			tim8_ch4n_pd0: tim8_ch4n_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF6)>;
 			};
 
-			tim8_ch4_pwm_pd1: tim8_ch4_pwm_pd1 {
+			tim8_ch4_pd1: tim8_ch4_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF4)>;
 			};
 

--- a/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
@@ -390,309 +390,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF6)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF6)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
 			};
 
-			tim1_ch1n_pwm_pa11: tim1_ch1n_pwm_pa11 {
+			tim1_ch1n_pa11: tim1_ch1n_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
 			};
 
-			tim1_ch2n_pwm_pa12: tim1_ch2n_pwm_pa12 {
+			tim1_ch2n_pa12: tim1_ch2n_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF12)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
 			};
 
-			tim1_ch1_pwm_pc0: tim1_ch1_pwm_pc0 {
+			tim1_ch1_pc0: tim1_ch1_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
 			};
 
-			tim1_ch2_pwm_pc1: tim1_ch2_pwm_pc1 {
+			tim1_ch2_pc1: tim1_ch2_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
 			};
 
-			tim1_ch3_pwm_pc2: tim1_ch3_pwm_pc2 {
+			tim1_ch3_pc2: tim1_ch3_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
 			};
 
-			tim1_ch4_pwm_pc3: tim1_ch4_pwm_pc3 {
+			tim1_ch4_pc3: tim1_ch4_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
 			};
 
-			tim1_ch4n_pwm_pc5: tim1_ch4n_pwm_pc5 {
+			tim1_ch4n_pc5: tim1_ch4n_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF6)>;
 			};
 
-			tim1_ch3n_pwm_pf0: tim1_ch3n_pwm_pf0 {
+			tim1_ch3n_pf0: tim1_ch3n_pf0 {
 				pinmux = <STM32_PINMUX('F', 0, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa9: tim2_ch3_pwm_pa9 {
+			tim2_ch3_pa9: tim2_ch3_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF10)>;
 			};
 
-			tim2_ch4_pwm_pa10: tim2_ch4_pwm_pa10 {
+			tim2_ch4_pa10: tim2_ch4_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF10)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch2_pwm_pa4: tim3_ch2_pwm_pa4 {
+			tim3_ch2_pa4: tim3_ch2_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb7: tim3_ch4_pwm_pb7 {
+			tim3_ch4_pb7: tim3_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim4_ch1_pwm_pa11: tim4_ch1_pwm_pa11 {
+			tim4_ch1_pa11: tim4_ch1_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF10)>;
 			};
 
-			tim4_ch2_pwm_pa12: tim4_ch2_pwm_pa12 {
+			tim4_ch2_pa12: tim4_ch2_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF10)>;
 			};
 
-			tim4_ch3_pwm_pa13: tim4_ch3_pwm_pa13 {
+			tim4_ch3_pa13: tim4_ch3_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF9)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF9)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			tim15_ch1n_pb15: tim15_ch1n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa12: tim16_ch1_pwm_pa12 {
+			tim16_ch1_pa12: tim16_ch1_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pa13: tim16_ch1n_pwm_pa13 {
+			tim16_ch1n_pa13: tim16_ch1n_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb4: tim16_ch1_pwm_pb4 {
+			tim16_ch1_pb4: tim16_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb5: tim17_ch1_pwm_pb5 {
+			tim17_ch1_pb5: tim17_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF4)>;
 			};
 
-			tim8_ch2_pwm_pa14: tim8_ch2_pwm_pa14 {
+			tim8_ch2_pa14: tim8_ch2_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF5)>;
 			};
 
-			tim8_ch1_pwm_pa15: tim8_ch1_pwm_pa15 {
+			tim8_ch1_pa15: tim8_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF2)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
 			};
 
-			tim8_ch1n_pwm_pb3: tim8_ch1n_pwm_pb3 {
+			tim8_ch1n_pb3: tim8_ch1n_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
 			};
 
-			tim8_ch2n_pwm_pb4: tim8_ch2n_pwm_pb4 {
+			tim8_ch2n_pb4: tim8_ch2n_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim8_ch3n_pwm_pb5: tim8_ch3n_pwm_pb5 {
+			tim8_ch3n_pb5: tim8_ch3n_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF3)>;
 			};
 
-			tim8_ch1_pwm_pb6: tim8_ch1_pwm_pb6 {
+			tim8_ch1_pb6: tim8_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim8_ch2_pwm_pb8: tim8_ch2_pwm_pb8 {
+			tim8_ch2_pb8: tim8_ch2_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF10)>;
 			};
 
-			tim8_ch3_pwm_pb9: tim8_ch3_pwm_pb9 {
+			tim8_ch3_pb9: tim8_ch3_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF10)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF4)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF4)>;
 			};
 

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1228,345 +1228,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1297,425 +1297,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1253,369 +1253,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1253,369 +1253,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1228,345 +1228,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1297,425 +1297,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1297,425 +1297,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1297,425 +1297,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1297,425 +1297,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1303,349 +1303,349 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1152,365 +1152,365 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1303,349 +1303,349 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1152,365 +1152,365 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1092,317 +1092,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1092,317 +1092,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1011,293 +1011,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1253,369 +1253,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1228,345 +1228,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1297,425 +1297,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -937,293 +937,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1297,425 +1297,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1303,349 +1303,349 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1152,365 +1152,365 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1092,317 +1092,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1277,369 +1277,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1132,317 +1132,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1361,425 +1361,425 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1011,293 +1011,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1026,341 +1026,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -1044,373 +1044,373 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1065,353 +1065,353 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -1044,373 +1044,373 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -972,369 +972,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -1118,429 +1118,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1064,429 +1064,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -904,289 +904,289 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -725,229 +725,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -796,297 +796,297 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -776,281 +776,281 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -796,297 +796,297 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -751,269 +751,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -952,321 +952,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -928,321 +928,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1026,341 +1026,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1065,353 +1065,353 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -1044,373 +1044,373 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -725,229 +725,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -796,297 +796,297 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -952,321 +952,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1026,341 +1026,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -1044,373 +1044,373 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1065,353 +1065,353 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -1044,373 +1044,373 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -972,369 +972,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -1118,429 +1118,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1064,429 +1064,429 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -904,289 +904,289 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -725,229 +725,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -796,297 +796,297 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -776,281 +776,281 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -796,297 +796,297 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -751,269 +751,269 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -952,321 +952,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -928,321 +928,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1_pwm_pc12: tim15_ch1_pwm_pc12 {
+			tim15_ch1_pc12: tim15_ch1_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
@@ -180,73 +180,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l010f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010f4px-pinctrl.dtsi
@@ -119,49 +119,49 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
@@ -170,85 +170,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb5: tim21_ch1_pwm_pb5 {
+			tim21_ch1_pb5: tim21_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
@@ -126,41 +126,41 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
@@ -162,57 +162,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
@@ -174,81 +174,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
@@ -84,25 +84,25 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
@@ -145,73 +145,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
@@ -119,49 +119,49 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
@@ -123,41 +123,41 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
@@ -160,81 +160,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb5: tim21_ch1_pwm_pb5 {
+			tim21_ch1_pb5: tim21_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
@@ -170,85 +170,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb5: tim21_ch1_pwm_pb5 {
+			tim21_ch1_pb5: tim21_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
@@ -181,85 +181,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb5: tim21_ch1_pwm_pb5 {
+			tim21_ch1_pb5: tim21_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l021d4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021d4px-pinctrl.dtsi
@@ -84,25 +84,25 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l021f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4px-pinctrl.dtsi
@@ -119,49 +119,49 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
@@ -123,41 +123,41 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
@@ -160,81 +160,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb5: tim21_ch1_pwm_pb5 {
+			tim21_ch1_pb5: tim21_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
@@ -170,85 +170,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb5: tim21_ch1_pwm_pb5 {
+			tim21_ch1_pb5: tim21_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
@@ -181,85 +181,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa9: tim21_ch2_pwm_pa9 {
+			tim21_ch2_pa9: tim21_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim21_ch1_pwm_pa10: tim21_ch1_pwm_pa10 {
+			tim21_ch1_pa10: tim21_ch1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb5: tim21_ch1_pwm_pb5 {
+			tim21_ch1_pb5: tim21_ch1_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim2_ch3_pwm_pa10: tim2_ch3_pwm_pa10 {
+			tim2_ch3_pa10: tim2_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb0: tim2_ch2_pwm_pb0 {
+			tim2_ch2_pb0: tim2_ch2_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim2_ch3_pwm_pb6: tim2_ch3_pwm_pb6 {
+			tim2_ch3_pb6: tim2_ch3_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb7: tim2_ch4_pwm_pb7 {
+			tim2_ch4_pb7: tim2_ch4_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
@@ -180,97 +180,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l031c6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c6ux-pinctrl.dtsi
@@ -180,97 +180,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
@@ -123,69 +123,69 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
@@ -97,53 +97,53 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
@@ -128,73 +128,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
@@ -138,81 +138,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
@@ -148,85 +148,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
@@ -154,85 +154,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
@@ -180,97 +180,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF5)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
@@ -123,69 +123,69 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l041f6px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041f6px-pinctrl.dtsi
@@ -97,53 +97,53 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 

--- a/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
@@ -128,73 +128,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
@@ -138,81 +138,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
@@ -148,85 +148,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
@@ -154,85 +154,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa11: tim21_ch2_pwm_pa11 {
+			tim21_ch2_pa11: tim21_ch2_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF5)>;
 			};
 
-			tim21_ch1_pwm_pb6: tim21_ch1_pwm_pb6 {
+			tim21_ch1_pb6: tim21_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa8: tim2_ch1_pwm_pa8 {
+			tim2_ch1_pa8: tim2_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa9: tim22_ch1_pwm_pa9 {
+			tim22_ch1_pa9: tim22_ch1_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa10: tim22_ch2_pwm_pa10 {
+			tim22_ch2_pa10: tim22_ch2_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch3_pwm_pb0: tim2_ch3_pwm_pb0 {
+			tim2_ch3_pb0: tim2_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF5)>;
 			};
 
-			tim2_ch4_pwm_pb1: tim2_ch4_pwm_pb1 {
+			tim2_ch4_pb1: tim2_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
@@ -215,73 +215,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
@@ -126,57 +126,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
@@ -132,57 +132,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
@@ -240,81 +240,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
@@ -253,81 +253,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
@@ -144,65 +144,65 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -221,73 +221,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
@@ -132,57 +132,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
@@ -138,57 +138,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -246,81 +246,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -259,81 +259,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
@@ -150,65 +150,65 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
@@ -150,65 +150,65 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -221,73 +221,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -246,81 +246,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -259,81 +259,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
@@ -132,57 +132,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
@@ -138,57 +138,57 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -221,73 +221,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -259,81 +259,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 

--- a/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
@@ -239,97 +239,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
@@ -239,97 +239,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
@@ -268,97 +268,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
@@ -239,97 +239,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
@@ -150,81 +150,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
@@ -140,73 +140,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
@@ -140,73 +140,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
@@ -282,121 +282,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
@@ -295,121 +295,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
@@ -348,177 +348,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
@@ -348,177 +348,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
@@ -348,177 +348,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
@@ -348,177 +348,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -249,97 +249,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -249,97 +249,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -278,97 +278,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -278,97 +278,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
@@ -160,81 +160,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
@@ -150,73 +150,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -292,121 +292,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -292,121 +292,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -305,121 +305,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -249,97 +249,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -249,97 +249,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -292,121 +292,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -305,121 +305,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -292,121 +292,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
@@ -239,97 +239,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l081czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081czux-pinctrl.dtsi
@@ -239,97 +239,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l081kztx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kztx-pinctrl.dtsi
@@ -150,81 +150,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l081kzux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kzux-pinctrl.dtsi
@@ -140,73 +140,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -249,97 +249,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -278,97 +278,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
@@ -160,81 +160,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
@@ -150,73 +150,73 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -249,97 +249,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -249,97 +249,97 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -292,121 +292,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -305,121 +305,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -358,177 +358,177 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim21_ch1_pwm_pa2: tim21_ch1_pwm_pa2 {
+			tim21_ch1_pa2: tim21_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF0)>;
 			};
 
-			tim21_ch2_pwm_pa3: tim21_ch2_pwm_pa3 {
+			tim21_ch2_pa3: tim21_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF0)>;
 			};
 
-			tim21_ch1_pwm_pb13: tim21_ch1_pwm_pb13 {
+			tim21_ch1_pb13: tim21_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
 			};
 
-			tim21_ch2_pwm_pb14: tim21_ch2_pwm_pb14 {
+			tim21_ch2_pb14: tim21_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
 			};
 
-			tim21_ch1_pwm_pd0: tim21_ch1_pwm_pd0 {
+			tim21_ch1_pd0: tim21_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF0)>;
 			};
 
-			tim21_ch2_pwm_pd7: tim21_ch2_pwm_pd7 {
+			tim21_ch2_pd7: tim21_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF1)>;
 			};
 
-			tim21_ch1_pwm_pe5: tim21_ch1_pwm_pe5 {
+			tim21_ch1_pe5: tim21_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF0)>;
 			};
 
-			tim21_ch2_pwm_pe6: tim21_ch2_pwm_pe6 {
+			tim21_ch2_pe6: tim21_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF0)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
 			};
 
-			tim22_ch1_pwm_pa6: tim22_ch1_pwm_pa6 {
+			tim22_ch1_pa6: tim22_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF5)>;
 			};
 
-			tim22_ch2_pwm_pa7: tim22_ch2_pwm_pa7 {
+			tim22_ch2_pa7: tim22_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF5)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF2)>;
 			};
 
-			tim22_ch1_pwm_pb4: tim22_ch1_pwm_pb4 {
+			tim22_ch1_pb4: tim22_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
 			};
 
-			tim22_ch2_pwm_pb5: tim22_ch2_pwm_pb5 {
+			tim22_ch2_pb5: tim22_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF2)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF2)>;
 			};
 
-			tim22_ch1_pwm_pc6: tim22_ch1_pwm_pc6 {
+			tim22_ch1_pc6: tim22_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF0)>;
 			};
 
-			tim22_ch2_pwm_pc7: tim22_ch2_pwm_pc7 {
+			tim22_ch2_pc7: tim22_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF0)>;
 			};
 
-			tim22_ch1_pwm_pe3: tim22_ch1_pwm_pe3 {
+			tim22_ch1_pe3: tim22_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF0)>;
 			};
 
-			tim22_ch2_pwm_pe4: tim22_ch2_pwm_pe4 {
+			tim22_ch2_pe4: tim22_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF0)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF0)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF0)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF0)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 

--- a/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
@@ -220,137 +220,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
@@ -220,137 +220,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -305,137 +305,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151cctx-pinctrl.dtsi
@@ -257,137 +257,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ccux-pinctrl.dtsi
@@ -257,137 +257,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -390,229 +390,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -390,229 +390,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -390,233 +390,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
@@ -216,137 +216,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
@@ -216,137 +216,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
@@ -220,137 +220,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
@@ -220,137 +220,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151retx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -374,213 +374,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -374,213 +374,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -394,229 +394,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -394,229 +394,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -394,233 +394,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
@@ -196,121 +196,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152cctx-pinctrl.dtsi
@@ -257,137 +257,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ccux-pinctrl.dtsi
@@ -257,137 +257,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -390,229 +390,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -390,229 +390,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -390,233 +390,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
@@ -216,137 +216,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
@@ -216,137 +216,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
@@ -220,137 +220,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
@@ -220,137 +220,137 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -276,201 +276,201 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -374,213 +374,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -374,213 +374,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -394,229 +394,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -394,229 +394,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -394,233 +394,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -390,229 +390,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -305,153 +305,153 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -374,213 +374,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -374,213 +374,213 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -374,217 +374,217 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -394,229 +394,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -394,233 +394,233 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim10_ch1_pwm_pa6: tim10_ch1_pwm_pa6 {
+			tim10_ch1_pa6: tim10_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			tim10_ch1_pb8: tim10_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF3)>;
 			};
 
-			tim10_ch1_pwm_pb12: tim10_ch1_pwm_pb12 {
+			tim10_ch1_pb12: tim10_ch1_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF3)>;
 			};
 
-			tim10_ch1_pwm_pe0: tim10_ch1_pwm_pe0 {
+			tim10_ch1_pe0: tim10_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF3)>;
 			};
 
-			tim11_ch1_pwm_pa7: tim11_ch1_pwm_pa7 {
+			tim11_ch1_pa7: tim11_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			tim11_ch1_pb9: tim11_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF3)>;
 			};
 
-			tim11_ch1_pwm_pb15: tim11_ch1_pwm_pb15 {
+			tim11_ch1_pb15: tim11_ch1_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim11_ch1_pwm_pe1: tim11_ch1_pwm_pe1 {
+			tim11_ch1_pe1: tim11_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF3)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim2_ch1_pwm_pe9: tim2_ch1_pwm_pe9 {
+			tim2_ch1_pe9: tim2_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim2_ch2_pwm_pe10: tim2_ch2_pwm_pe10 {
+			tim2_ch2_pe10: tim2_ch2_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim2_ch3_pwm_pe11: tim2_ch3_pwm_pe11 {
+			tim2_ch3_pe11: tim2_ch3_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim2_ch4_pwm_pe12: tim2_ch4_pwm_pe12 {
+			tim2_ch4_pe12: tim2_ch4_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			tim9_ch1_pa2: tim9_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF3)>;
 			};
 
-			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			tim9_ch2_pa3: tim9_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 			};
 
-			tim9_ch1_pwm_pb13: tim9_ch1_pwm_pb13 {
+			tim9_ch1_pb13: tim9_ch1_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF3)>;
 			};
 
-			tim9_ch2_pwm_pb14: tim9_ch2_pwm_pb14 {
+			tim9_ch2_pb14: tim9_ch2_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim9_ch1_pwm_pd0: tim9_ch1_pwm_pd0 {
+			tim9_ch1_pd0: tim9_ch1_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF3)>;
 			};
 
-			tim9_ch2_pwm_pd7: tim9_ch2_pwm_pd7 {
+			tim9_ch2_pd7: tim9_ch2_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF3)>;
 			};
 
-			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			tim9_ch1_pe5: tim9_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF3)>;
 			};
 
-			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			tim9_ch2_pe6: tim9_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -258,117 +258,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -258,117 +258,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -258,117 +258,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -246,109 +246,109 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -258,117 +258,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -246,109 +246,109 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -192,81 +192,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -192,81 +192,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -192,81 +192,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -192,81 +192,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -328,117 +328,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -328,117 +328,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -328,117 +328,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -320,117 +320,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -328,117 +328,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -320,117 +320,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -198,89 +198,89 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -198,89 +198,89 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -192,85 +192,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -258,117 +258,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -258,117 +258,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -192,81 +192,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -192,81 +192,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -328,117 +328,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -328,117 +328,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -198,89 +198,89 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -283,117 +283,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -283,117 +283,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -292,117 +292,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -208,81 +208,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -445,149 +445,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -445,149 +445,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -208,81 +208,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -283,117 +283,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -283,117 +283,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -292,117 +292,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -340,117 +340,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -445,149 +445,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -445,149 +445,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -208,81 +208,81 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -283,117 +283,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -283,117 +283,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -292,117 +292,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -396,117 +396,117 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -445,149 +445,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -445,149 +445,149 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -321,141 +321,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -507,205 +507,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -507,205 +507,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -321,141 +321,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -390,157 +390,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -507,205 +507,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -507,205 +507,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -321,141 +321,141 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -446,157 +446,157 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -507,205 +507,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -507,205 +507,205 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -569,321 +569,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -432,241 +432,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -481,309 +481,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -589,345 +589,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -589,345 +589,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -432,241 +432,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -481,309 +481,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -464,253 +464,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -451,249 +451,249 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -469,257 +469,257 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -569,321 +569,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -432,241 +432,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -481,309 +481,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -589,345 +589,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -589,345 +589,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -583,341 +583,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -464,253 +464,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -464,253 +464,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -569,321 +569,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -432,241 +432,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -481,309 +481,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -589,345 +589,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -757,369 +757,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -757,365 +757,365 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -700,321 +700,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -682,317 +682,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -534,241 +534,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -474,241 +474,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -600,309 +600,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -598,305 +598,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -590,305 +590,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -720,345 +720,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -708,341 +708,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -757,369 +757,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -757,365 +757,365 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -700,321 +700,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -682,317 +682,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -534,241 +534,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -521,241 +521,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -600,309 +600,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -598,305 +598,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -590,305 +590,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -720,345 +720,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -708,341 +708,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -835,369 +835,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -835,365 +835,365 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -382,209 +382,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -382,209 +382,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -354,197 +354,197 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -354,197 +354,197 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -782,321 +782,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -764,317 +764,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -568,241 +568,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -555,241 +555,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -654,309 +654,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -672,305 +672,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -642,301 +642,301 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -664,305 +664,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -782,345 +782,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -770,341 +770,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -771,369 +771,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -382,209 +382,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -382,209 +382,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -782,321 +782,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -568,241 +568,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -654,309 +654,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -672,305 +672,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -782,345 +782,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -656,369 +656,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -603,321 +603,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -515,309 +515,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -603,345 +603,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -592,329 +592,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -591,341 +591,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -656,369 +656,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -515,309 +515,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -603,345 +603,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -640,369 +640,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -499,293 +499,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -592,341 +592,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -587,333 +587,333 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -592,329 +592,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -574,325 +574,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -656,369 +656,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -603,321 +603,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -515,309 +515,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -603,345 +603,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -592,329 +592,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -656,369 +656,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -515,309 +515,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -603,345 +603,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -640,369 +640,369 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -499,293 +499,293 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -592,341 +592,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -587,333 +587,333 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -592,329 +592,329 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -338,209 +338,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -338,209 +338,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -311,197 +311,197 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -311,197 +311,197 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -544,261 +544,261 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -529,253 +529,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -646,317 +646,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -663,321 +663,321 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -658,317 +658,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -505,241 +505,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -420,241 +420,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -447,229 +447,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -554,305 +554,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -575,309 +575,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -637,341 +637,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -663,345 +663,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -338,209 +338,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -311,197 +311,197 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -338,209 +338,209 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -311,197 +311,197 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -544,261 +544,261 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -529,253 +529,253 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -575,309 +575,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -658,317 +658,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -646,317 +646,317 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -505,241 +505,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -420,241 +420,241 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -447,229 +447,229 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -575,309 +575,309 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -554,305 +554,305 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -663,345 +663,345 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim15_ch2_pwm_pg11: tim15_ch2_pwm_pg11 {
+			tim15_ch2_pg11: tim15_ch2_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -637,341 +637,341 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim3_ch1_pwm_pe3: tim3_ch1_pwm_pe3 {
+			tim3_ch1_pe3: tim3_ch1_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF2)>;
 			};
 
-			tim3_ch2_pwm_pe4: tim3_ch2_pwm_pe4 {
+			tim3_ch2_pe4: tim3_ch2_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF2)>;
 			};
 
-			tim3_ch3_pwm_pe5: tim3_ch3_pwm_pe5 {
+			tim3_ch3_pe5: tim3_ch3_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF2)>;
 			};
 
-			tim3_ch4_pwm_pe6: tim3_ch4_pwm_pe6 {
+			tim3_ch4_pe6: tim3_ch4_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF2)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF14)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pb13: tim15_ch1n_pwm_pb13 {
+			tim15_ch1n_pb13: tim15_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
 			};
 
-			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			tim15_ch1_pb14: tim15_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF14)>;
 			};
 
-			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			tim15_ch2_pb15: tim15_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF14)>;
 			};
 
-			tim5_ch1_pwm_pf6: tim5_ch1_pwm_pf6 {
+			tim5_ch1_pf6: tim5_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF2)>;
 			};
 
-			tim5_ch2_pwm_pf7: tim5_ch2_pwm_pf7 {
+			tim5_ch2_pf7: tim5_ch2_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF2)>;
 			};
 
-			tim5_ch3_pwm_pf8: tim5_ch3_pwm_pf8 {
+			tim5_ch3_pf8: tim5_ch3_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF2)>;
 			};
 
-			tim15_ch1_pwm_pf9: tim15_ch1_pwm_pf9 {
+			tim15_ch1_pf9: tim15_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF14)>;
 			};
 
-			tim5_ch4_pwm_pf9: tim5_ch4_pwm_pf9 {
+			tim5_ch4_pf9: tim5_ch4_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF2)>;
 			};
 
-			tim15_ch2_pwm_pf10: tim15_ch2_pwm_pf10 {
+			tim15_ch2_pf10: tim15_ch2_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF14)>;
 			};
 
-			tim15_ch1n_pwm_pg9: tim15_ch1n_pwm_pg9 {
+			tim15_ch1n_pg9: tim15_ch1n_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF14)>;
 			};
 
-			tim15_ch1_pwm_pg10: tim15_ch1_pwm_pg10 {
+			tim15_ch1_pg10: tim15_ch1_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF14)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1464,433 +1464,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1444,377 +1444,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1464,433 +1464,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1444,377 +1444,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1464,433 +1464,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1444,377 +1444,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1464,433 +1464,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1444,377 +1444,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1053,325 +1053,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1520,433 +1520,433 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pj8: tim1_ch3n_pwm_pj8 {
+			tim1_ch3n_pj8: tim1_ch3n_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF1)>;
 			};
 
-			tim1_ch3_pwm_pj9: tim1_ch3_pwm_pj9 {
+			tim1_ch3_pj9: tim1_ch3_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pj10: tim1_ch2n_pwm_pj10 {
+			tim1_ch2n_pj10: tim1_ch2n_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pj11: tim1_ch2_pwm_pj11 {
+			tim1_ch2_pj11: tim1_ch2_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pk0: tim1_ch1n_pwm_pk0 {
+			tim1_ch1n_pk0: tim1_ch1n_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF1)>;
 			};
 
-			tim1_ch1_pwm_pk1: tim1_ch1_pwm_pk1 {
+			tim1_ch1_pk1: tim1_ch1_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj6: tim8_ch2_pwm_pj6 {
+			tim8_ch2_pj6: tim8_ch2_pj6 {
 				pinmux = <STM32_PINMUX('J', 6, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj7: tim8_ch2n_pwm_pj7 {
+			tim8_ch2n_pj7: tim8_ch2n_pj7 {
 				pinmux = <STM32_PINMUX('J', 7, AF3)>;
 			};
 
-			tim8_ch1_pwm_pj8: tim8_ch1_pwm_pj8 {
+			tim8_ch1_pj8: tim8_ch1_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pj9: tim8_ch1n_pwm_pj9 {
+			tim8_ch1n_pj9: tim8_ch1n_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF3)>;
 			};
 
-			tim8_ch2_pwm_pj10: tim8_ch2_pwm_pj10 {
+			tim8_ch2_pj10: tim8_ch2_pj10 {
 				pinmux = <STM32_PINMUX('J', 10, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pj11: tim8_ch2n_pwm_pj11 {
+			tim8_ch2n_pj11: tim8_ch2n_pj11 {
 				pinmux = <STM32_PINMUX('J', 11, AF3)>;
 			};
 
-			tim8_ch3_pwm_pk0: tim8_ch3_pwm_pk0 {
+			tim8_ch3_pk0: tim8_ch3_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pk1: tim8_ch3n_pwm_pk1 {
+			tim8_ch3n_pk1: tim8_ch3n_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1500,377 +1500,377 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim12_ch1_pwm_ph6: tim12_ch1_pwm_ph6 {
+			tim12_ch1_ph6: tim12_ch1_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF2)>;
 			};
 
-			tim12_ch2_pwm_ph9: tim12_ch2_pwm_ph9 {
+			tim12_ch2_ph9: tim12_ch2_ph9 {
 				pinmux = <STM32_PINMUX('H', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim5_ch1_pwm_ph10: tim5_ch1_pwm_ph10 {
+			tim5_ch1_ph10: tim5_ch1_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF2)>;
 			};
 
-			tim5_ch2_pwm_ph11: tim5_ch2_pwm_ph11 {
+			tim5_ch2_ph11: tim5_ch2_ph11 {
 				pinmux = <STM32_PINMUX('H', 11, AF2)>;
 			};
 
-			tim5_ch3_pwm_ph12: tim5_ch3_pwm_ph12 {
+			tim5_ch3_ph12: tim5_ch3_ph12 {
 				pinmux = <STM32_PINMUX('H', 12, AF2)>;
 			};
 
-			tim5_ch4_pwm_pi0: tim5_ch4_pwm_pi0 {
+			tim5_ch4_pi0: tim5_ch4_pi0 {
 				pinmux = <STM32_PINMUX('I', 0, AF2)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 
-			tim8_ch1n_pwm_ph13: tim8_ch1n_pwm_ph13 {
+			tim8_ch1n_ph13: tim8_ch1n_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF3)>;
 			};
 
-			tim8_ch2n_pwm_ph14: tim8_ch2n_pwm_ph14 {
+			tim8_ch2n_ph14: tim8_ch2n_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_ph15: tim8_ch3n_pwm_ph15 {
+			tim8_ch3n_ph15: tim8_ch3n_ph15 {
 				pinmux = <STM32_PINMUX('H', 15, AF3)>;
 			};
 
-			tim8_ch4_pwm_pi2: tim8_ch4_pwm_pi2 {
+			tim8_ch4_pi2: tim8_ch4_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF3)>;
 			};
 
-			tim8_ch1_pwm_pi5: tim8_ch1_pwm_pi5 {
+			tim8_ch1_pi5: tim8_ch1_pi5 {
 				pinmux = <STM32_PINMUX('I', 5, AF3)>;
 			};
 
-			tim8_ch2_pwm_pi6: tim8_ch2_pwm_pi6 {
+			tim8_ch2_pi6: tim8_ch2_pi6 {
 				pinmux = <STM32_PINMUX('I', 6, AF3)>;
 			};
 
-			tim8_ch3_pwm_pi7: tim8_ch3_pwm_pi7 {
+			tim8_ch3_pi7: tim8_ch3_pi7 {
 				pinmux = <STM32_PINMUX('I', 7, AF3)>;
 			};
 

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1097,325 +1097,325 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			tim1_ch2n_pb0: tim1_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			tim1_ch3n_pb1: tim1_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			tim1_ch1n_pe8: tim1_ch1n_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
 			};
 
-			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			tim1_ch1_pe9: tim1_ch1_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			tim1_ch2n_pe10: tim1_ch2n_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
 			};
 
-			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			tim1_ch2_pe11: tim1_ch2_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			tim1_ch3n_pe12: tim1_ch3n_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF1)>;
 			};
 
-			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			tim1_ch3_pe13: tim1_ch3_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
 			};
 
-			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			tim1_ch4_pe14: tim1_ch4_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			tim12_ch1_pb14: tim12_ch1_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF2)>;
 			};
 
-			tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			tim12_ch2_pb15: tim12_ch2_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF2)>;
 			};
 
-			tim2_ch1_pwm_pg8: tim2_ch1_pwm_pg8 {
+			tim2_ch1_pg8: tim2_ch1_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF1)>;
 			};
 
-			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			tim13_ch1_pa6: tim13_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF9)>;
 			};
 
-			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			tim3_ch1_pa6: tim3_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			tim3_ch2_pa7: tim3_ch2_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			tim3_ch3_pb0: tim3_ch3_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF2)>;
 			};
 
-			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			tim3_ch4_pb1: tim3_ch4_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF2)>;
 			};
 
-			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			tim3_ch1_pb4: tim3_ch1_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF2)>;
 			};
 
-			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			tim3_ch2_pb5: tim3_ch2_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF2)>;
 			};
 
-			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			tim3_ch1_pc6: tim3_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF2)>;
 			};
 
-			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			tim3_ch2_pc7: tim3_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF2)>;
 			};
 
-			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			tim3_ch3_pc8: tim3_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF2)>;
 			};
 
-			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			tim3_ch4_pc9: tim3_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF2)>;
 			};
 
-			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			tim13_ch1_pf8: tim13_ch1_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF9)>;
 			};
 
-			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			tim14_ch1_pa7: tim14_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF9)>;
 			};
 
-			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			tim4_ch1_pb6: tim4_ch1_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF2)>;
 			};
 
-			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			tim4_ch2_pb7: tim4_ch2_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF2)>;
 			};
 
-			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			tim4_ch3_pb8: tim4_ch3_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF2)>;
 			};
 
-			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			tim4_ch4_pb9: tim4_ch4_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF2)>;
 			};
 
-			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			tim4_ch1_pd12: tim4_ch1_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
 			};
 
-			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			tim4_ch2_pd13: tim4_ch2_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF2)>;
 			};
 
-			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			tim4_ch3_pd14: tim4_ch3_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF2)>;
 			};
 
-			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			tim4_ch4_pd15: tim4_ch4_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
 			};
 
-			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			tim14_ch1_pf9: tim14_ch1_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF9)>;
 			};
 
-			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pa1: tim15_ch1n_pwm_pa1 {
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
-			tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			tim5_ch2_pa1: tim5_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
-			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			tim15_ch1_pa2: tim15_ch1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
 			};
 
-			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			tim5_ch3_pa2: tim5_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF2)>;
 			};
 
-			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			tim15_ch2_pa3: tim15_ch2_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
 			};
 
-			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			tim5_ch4_pa3: tim5_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF2)>;
 			};
 
-			tim15_ch1n_pwm_pe4: tim15_ch1n_pwm_pe4 {
+			tim15_ch1n_pe4: tim15_ch1n_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF4)>;
 			};
 
-			tim15_ch1_pwm_pe5: tim15_ch1_pwm_pe5 {
+			tim15_ch1_pe5: tim15_ch1_pe5 {
 				pinmux = <STM32_PINMUX('E', 5, AF4)>;
 			};
 
-			tim15_ch2_pwm_pe6: tim15_ch2_pwm_pe6 {
+			tim15_ch2_pe6: tim15_ch2_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF4)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pd6: tim16_ch1n_pwm_pd6 {
+			tim16_ch1n_pd6: tim16_ch1n_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF1)>;
 			};
 
-			tim16_ch1_pwm_pf6: tim16_ch1_pwm_pf6 {
+			tim16_ch1_pf6: tim16_ch1_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
 			};
 
-			tim16_ch1n_pwm_pf8: tim16_ch1n_pwm_pf8 {
+			tim16_ch1n_pf8: tim16_ch1n_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim17_ch1_pwm_pf7: tim17_ch1_pwm_pf7 {
+			tim17_ch1_pf7: tim17_ch1_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF1)>;
 			};
 
-			tim17_ch1n_pwm_pf9: tim17_ch1n_pwm_pf9 {
+			tim17_ch1n_pf9: tim17_ch1n_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
 			};
 
-			tim8_ch1n_pwm_pa5: tim8_ch1n_pwm_pa5 {
+			tim8_ch1n_pa5: tim8_ch1n_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
 			};
 
-			tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			tim8_ch1n_pa7: tim8_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			tim8_ch2n_pb0: tim8_ch2n_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			tim8_ch3n_pb1: tim8_ch3n_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF3)>;
 			};
 
-			tim8_ch2n_pwm_pb14: tim8_ch2n_pwm_pb14 {
+			tim8_ch2n_pb14: tim8_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF3)>;
 			};
 
-			tim8_ch3n_pwm_pb15: tim8_ch3n_pwm_pb15 {
+			tim8_ch3n_pb15: tim8_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF3)>;
 			};
 
-			tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			tim8_ch1_pc6: tim8_ch1_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
 			};
 
-			tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			tim8_ch2_pc7: tim8_ch2_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
 			};
 
-			tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			tim8_ch3_pc8: tim8_ch3_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF3)>;
 			};
 
-			tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			tim8_ch4_pc9: tim8_ch4_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
 			};
 

--- a/dts/st/wb/stm32wb30ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb30ceux-pinctrl.dtsi
@@ -180,85 +180,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb35c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)ux-pinctrl.dtsi
@@ -305,85 +305,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb35c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)yx-pinctrl.dtsi
@@ -191,69 +191,69 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
@@ -160,85 +160,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -172,85 +172,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -172,85 +172,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -172,85 +172,85 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -292,105 +292,105 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -292,105 +292,105 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -292,105 +292,105 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -307,121 +307,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pd14: tim1_ch1_pwm_pd14 {
+			tim1_ch1_pd14: tim1_ch1_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF1)>;
 			};
 
-			tim1_ch2_pwm_pd15: tim1_ch2_pwm_pd15 {
+			tim1_ch2_pd15: tim1_ch2_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -307,121 +307,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pd14: tim1_ch1_pwm_pd14 {
+			tim1_ch1_pd14: tim1_ch1_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF1)>;
 			};
 
-			tim1_ch2_pwm_pd15: tim1_ch2_pwm_pd15 {
+			tim1_ch2_pd15: tim1_ch2_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -307,121 +307,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pd14: tim1_ch1_pwm_pd14 {
+			tim1_ch1_pd14: tim1_ch1_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF1)>;
 			};
 
-			tim1_ch2_pwm_pd15: tim1_ch2_pwm_pd15 {
+			tim1_ch2_pd15: tim1_ch2_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -307,121 +307,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pd14: tim1_ch1_pwm_pd14 {
+			tim1_ch1_pd14: tim1_ch1_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF1)>;
 			};
 
-			tim1_ch2_pwm_pd15: tim1_ch2_pwm_pd15 {
+			tim1_ch2_pd15: tim1_ch2_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -307,121 +307,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pd14: tim1_ch1_pwm_pd14 {
+			tim1_ch1_pd14: tim1_ch1_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF1)>;
 			};
 
-			tim1_ch2_pwm_pd15: tim1_ch2_pwm_pd15 {
+			tim1_ch2_pd15: tim1_ch2_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -307,121 +307,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pd14: tim1_ch1_pwm_pd14 {
+			tim1_ch1_pd14: tim1_ch1_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF1)>;
 			};
 
-			tim1_ch2_pwm_pd15: tim1_ch2_pwm_pd15 {
+			tim1_ch2_pd15: tim1_ch2_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -307,121 +307,121 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH / TIM_CHN */
 
-			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			tim1_ch1n_pa7: tim1_ch1n_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF1)>;
 			};
 
-			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			tim1_ch1_pa8: tim1_ch1_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF1)>;
 			};
 
-			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 			};
 
-			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			tim1_ch3_pa10: tim1_ch3_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			tim1_ch4_pa11: tim1_ch4_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb8: tim1_ch2n_pwm_pb8 {
+			tim1_ch2n_pb8: tim1_ch2n_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb9: tim1_ch3n_pwm_pb9 {
+			tim1_ch3n_pb9: tim1_ch3n_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF1)>;
 			};
 
-			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			tim1_ch1n_pb13: tim1_ch1n_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF1)>;
 			};
 
-			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			tim1_ch2n_pb14: tim1_ch2n_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF1)>;
 			};
 
-			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			tim1_ch3n_pb15: tim1_ch3n_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF1)>;
 			};
 
-			tim1_ch1_pwm_pd14: tim1_ch1_pwm_pd14 {
+			tim1_ch1_pd14: tim1_ch1_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF1)>;
 			};
 
-			tim1_ch2_pwm_pd15: tim1_ch2_pwm_pd15 {
+			tim1_ch2_pd15: tim1_ch2_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			tim2_ch1_pa0: tim2_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
-			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			tim2_ch3_pa2: tim2_ch3_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
 			};
 
-			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			tim2_ch4_pa3: tim2_ch4_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa5: tim2_ch1_pwm_pa5 {
+			tim2_ch1_pa5: tim2_ch1_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF1)>;
 			};
 
-			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			tim2_ch1_pa15: tim2_ch1_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
-			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			tim2_ch2_pb3: tim2_ch2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF1)>;
 			};
 
-			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			tim2_ch3_pb10: tim2_ch3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
 			};
 
-			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			tim2_ch4_pb11: tim2_ch4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
 			};
 
-			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			tim16_ch1_pa6: tim16_ch1_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF14)>;
 			};
 
-			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			tim16_ch1n_pb6: tim16_ch1n_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
 			};
 
-			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			tim16_ch1_pb8: tim16_ch1_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF14)>;
 			};
 
-			tim16_ch1_pwm_pe0: tim16_ch1_pwm_pe0 {
+			tim16_ch1_pe0: tim16_ch1_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF14)>;
 			};
 
-			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			tim17_ch1_pa7: tim17_ch1_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF14)>;
 			};
 
-			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			tim17_ch1n_pb7: tim17_ch1n_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF14)>;
 			};
 
-			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			tim17_ch1_pb9: tim17_ch1_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF14)>;
 			};
 
-			tim17_ch1_pwm_pe1: tim17_ch1_pwm_pe1 {
+			tim17_ch1_pe1: tim17_ch1_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF14)>;
 			};
 

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -209,10 +209,9 @@
   mode: alternate
   bias: pull-up
 
-- name: TIM_CH_PWM / TIM_CHN_PWM
+- name: TIM_CH / TIM_CHN
   match: "^TIM\\d+_CH\\d+N?$"
   mode: alternate
-  variant: pwm
 
 - name: UART_CTS / USART_CTS / LPUART_CTS
   match: "^(?:LP)?US?ART\\d+_CTS$"


### PR DESCRIPTION
STM32 timers are multi-purpose peripherals ranging from PWM, Input
capture, encoder, HALL sensor... In all series except F1 the timer pins
will always be configured in the same mode, i.e. alternate. So using a
variant for each functionality is not necessary. When working with F1
series mode is still required because the pin may operate in either
alternate or input mode depending on the assigned functionality.